### PR TITLE
fix version checks in tests

### DIFF
--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -1,6 +1,6 @@
 package TestApp;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 use parent 'Catalyst';
 
 __PACKAGE__->setup;

--- a/t/lib/TestCGIBin.pm
+++ b/t/lib/TestCGIBin.pm
@@ -1,6 +1,6 @@
 package TestCGIBin;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 use parent 'Catalyst';
 
 __PACKAGE__->config({

--- a/t/lib/TestCGIBinChainRoot.pm
+++ b/t/lib/TestCGIBinChainRoot.pm
@@ -1,6 +1,6 @@
 package TestCGIBinChainRoot;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 use parent 'Catalyst';
 
 __PACKAGE__->config({

--- a/t/lib/TestCGIBinRoot.pm
+++ b/t/lib/TestCGIBinRoot.pm
@@ -1,6 +1,6 @@
 package TestCGIBinRoot;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 use parent 'Catalyst';
 
 __PACKAGE__->config({

--- a/t/lib/TestCGIBinRoot2.pm
+++ b/t/lib/TestCGIBinRoot2.pm
@@ -1,6 +1,6 @@
 package TestCGIBinRoot2;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 use parent 'Catalyst';
 
 __PACKAGE__->config({

--- a/t/lib/TestCGIBinRoot3.pm
+++ b/t/lib/TestCGIBinRoot3.pm
@@ -1,6 +1,6 @@
 package TestCGIBinRoot3;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 use parent 'Catalyst';
 
 __PACKAGE__->setup(qw/Static::Simple/);

--- a/t/lib/TestGC.pm
+++ b/t/lib/TestGC.pm
@@ -1,6 +1,6 @@
 package TestGC;
 
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 use parent 'Catalyst';
 
 __PACKAGE__->setup;


### PR DESCRIPTION
The tests include version checks, but their syntax was wrong. Versions in a use line need to be entirely numeric or v prefixed numbers. Strings are instead passed to the import method. This would be ignored. Future versions of perl are intending to throw errors for unhandled import arguments.